### PR TITLE
Add CheckForUpdates boundary

### DIFF
--- a/src/main/java/org/hydev/mcpm/client/database/DatabaseInteractor.java
+++ b/src/main/java/org/hydev/mcpm/client/database/DatabaseInteractor.java
@@ -1,22 +1,33 @@
 package org.hydev.mcpm.client.database;
 
+import org.hydev.mcpm.client.database.boundary.CheckForUpdatesBoundary;
 import org.hydev.mcpm.client.database.boundary.ListPackagesBoundary;
+import org.hydev.mcpm.client.database.boundary.MatchPluginsBoundary;
 import org.hydev.mcpm.client.database.fetcher.DatabaseFetcher;
 import org.hydev.mcpm.client.database.fetcher.DatabaseFetcherListener;
 import org.hydev.mcpm.client.database.fetcher.LocalDatabaseFetcher;
 import org.hydev.mcpm.client.database.fetcher.ProgressBarFetcherListener;
+import org.hydev.mcpm.client.database.inputs.CheckForUpdatesInput;
+import org.hydev.mcpm.client.database.inputs.CheckForUpdatesResult;
 import org.hydev.mcpm.client.database.inputs.ListPackagesInput;
 import org.hydev.mcpm.client.database.inputs.ListPackagesResult;
+import org.hydev.mcpm.client.database.inputs.MatchPluginsInput;
+import org.hydev.mcpm.client.database.inputs.MatchPluginsResult;
+import org.hydev.mcpm.client.database.model.PluginModelId;
+import org.hydev.mcpm.client.database.model.PluginVersionState;
+import org.hydev.mcpm.client.models.PluginModel;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * Handles fetching and performing operations on the plugin database.
  */
-public class DatabaseInteractor implements ListPackagesBoundary {
+public class DatabaseInteractor implements ListPackagesBoundary, MatchPluginsBoundary, CheckForUpdatesBoundary {
     private final DatabaseFetcher fetcher;
     private final DatabaseFetcherListener listener;
 
@@ -89,6 +100,113 @@ public class DatabaseInteractor implements ListPackagesBoundary {
     }
 
     /**
+     * Checks for plugin updates.
+     *
+     * @param forInput A list of all plugins + plugin version identifiers that will be checked for updates.
+     * @return A list of plugins that needs updates in CheckForUpdatesResult#updates.
+     */
+    @Override
+    public CheckForUpdatesResult updates(CheckForUpdatesInput forInput) {
+        var isVersionsValid = forInput.states().stream()
+            .allMatch(state -> state.versionId().valid());
+
+        if (!isVersionsValid) {
+            return CheckForUpdatesResult.by(CheckForUpdatesResult.State.INVALID_INPUT);
+        }
+
+        var matchInput = new MatchPluginsInput(
+            forInput.states().stream().map(PluginVersionState::modelId).toList(),
+            forInput.noCache()
+        );
+
+        var result = match(matchInput);
+
+        switch (result.state()) {
+            case SUCCESS -> {
+                var mismatchedSet = Set.copyOf(result.mismatched());
+                var mismatched = forInput.states().stream()
+                    .filter(state -> mismatchedSet.contains(state.modelId()))
+                    .toList();
+
+                var updatable = new HashMap<PluginVersionState, PluginModel>();
+
+                for (var state : forInput.states()) {
+                    var value = result.matched().get(state.modelId());
+
+                    if (value == null) {
+                        continue;
+                    }
+
+                    var optionalLatest = value.latest();
+
+                    // guard let?
+                    if (optionalLatest.isEmpty()) {
+                        return null;
+                    }
+
+                    var latest = optionalLatest.get();
+
+                    if (!state.versionId().matches(latest)) {
+                        updatable.put(state, value);
+                    }
+                }
+
+                return new CheckForUpdatesResult(CheckForUpdatesResult.State.SUCCESS, updatable, mismatched);
+            }
+            case INVALID_INPUT -> {
+                return CheckForUpdatesResult.by(CheckForUpdatesResult.State.INVALID_INPUT);
+            }
+            case FAILED_TO_FETCH_DATABASE -> {
+                return CheckForUpdatesResult.by(CheckForUpdatesResult.State.FAILED_TO_FETCH_DATABASE);
+            }
+        }
+
+        return CheckForUpdatesResult.by(CheckForUpdatesResult.State.INVALID_INPUT);
+    }
+
+    /**
+     * Checks for plugins that match the provided identifiers.
+     *
+     * @param input A list of plugin identifiers that will be searched for in the database.
+     * @return A list of plugins that match the identifiers in MatchPluginsResult#matched.
+     */
+    @Override
+    public MatchPluginsResult match(MatchPluginsInput input) {
+        // Fail fast.
+        var validState = input.pluginIds().stream()
+            .allMatch(PluginModelId::valid);
+
+        if (!validState) {
+            return MatchPluginsResult.by(MatchPluginsResult.State.INVALID_INPUT);
+        }
+
+        var database = fetcher.fetchDatabase(!input.noCache(), listener);
+
+        if (database == null) {
+            return MatchPluginsResult.by(MatchPluginsResult.State.FAILED_TO_FETCH_DATABASE);
+        }
+
+        var matched = new HashMap<PluginModelId, PluginModel>();
+        var unmatched = new ArrayList<PluginModelId>();
+
+        for (var id : input.pluginIds()) {
+            var match = database
+                .plugins()
+                .stream()
+                .filter(id::matches)
+                .findFirst();
+
+            if (match.isEmpty()) {
+                unmatched.add(id);
+            } else {
+                matched.put(id, match.get());
+            }
+        }
+
+        return new MatchPluginsResult(MatchPluginsResult.State.SUCCESS, matched, unmatched);
+    }
+
+    /**
      * Demo main method for DatabaseInteractor.
      *
      * @param args Arguments are ignored.
@@ -118,4 +236,5 @@ public class DatabaseInteractor implements ListPackagesBoundary {
 
         System.out.println(text);
     }
+
 }

--- a/src/main/java/org/hydev/mcpm/client/database/DatabaseInteractor.java
+++ b/src/main/java/org/hydev/mcpm/client/database/DatabaseInteractor.java
@@ -131,7 +131,7 @@ public class DatabaseInteractor implements ListPackagesBoundary, MatchPluginsBou
                 var updatable = new HashMap<PluginVersionState, PluginModel>();
 
                 for (var state : forInput.states()) {
-                    var value = result.matched().get(state.modelId());
+                    var value = result.matched().getOrDefault(state.modelId(), null);
 
                     if (value == null) {
                         continue;

--- a/src/main/java/org/hydev/mcpm/client/database/DatabaseInteractor.java
+++ b/src/main/java/org/hydev/mcpm/client/database/DatabaseInteractor.java
@@ -20,6 +20,7 @@ import org.hydev.mcpm.client.models.PluginModel;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -235,6 +236,31 @@ public class DatabaseInteractor implements ListPackagesBoundary, MatchPluginsBou
             .collect(Collectors.joining("\n"));
 
         System.out.println(text);
-    }
 
+        var matchInput = new MatchPluginsInput(List.of(
+            PluginModelId.byId(100429),
+            PluginModelId.byMain("com.gestankbratwurst.smilecore.SmileCore"),
+            PluginModelId.byName("JedCore")
+        ), false);
+
+        var matchResult = database.match(matchInput);
+
+        if (matchResult.state() != MatchPluginsResult.State.SUCCESS) {
+            System.out.println("Match Result Failed With State " + result.state().name());
+            return;
+        }
+
+        System.out.println("Match Result (" + matchResult.mismatched().size() + " mismatched):");
+
+        var matchText = matchResult
+            .matched()
+            .values()
+            .stream()
+            .map(PluginModel::id)
+            .map(String::valueOf)
+            .map(value -> "  " + value)
+            .collect(Collectors.joining("\n"));
+
+        System.out.println(matchText);
+    }
 }

--- a/src/main/java/org/hydev/mcpm/client/database/boundary/CheckForUpdatesBoundary.java
+++ b/src/main/java/org/hydev/mcpm/client/database/boundary/CheckForUpdatesBoundary.java
@@ -1,0 +1,17 @@
+package org.hydev.mcpm.client.database.boundary;
+
+import org.hydev.mcpm.client.database.inputs.CheckForUpdatesInput;
+import org.hydev.mcpm.client.database.inputs.CheckForUpdatesResult;
+
+/**
+ * Defines how a user can search for plugin updates.
+ */
+public interface CheckForUpdatesBoundary {
+    /**
+     * Looks through the database for plugins in CheckForUpdatesInput that have an updated version.
+     *
+     * @param forInput A list of all plugins + plugin version identifiers that will be checked for updates.
+     * @return A list of plugins that need updates in CheckForUpdatesResult#updatable.
+     */
+    CheckForUpdatesResult updates(CheckForUpdatesInput forInput);
+}

--- a/src/main/java/org/hydev/mcpm/client/database/boundary/MatchPluginsBoundary.java
+++ b/src/main/java/org/hydev/mcpm/client/database/boundary/MatchPluginsBoundary.java
@@ -1,0 +1,21 @@
+package org.hydev.mcpm.client.database.boundary;
+
+import org.hydev.mcpm.client.database.inputs.MatchPluginsInput;
+import org.hydev.mcpm.client.database.inputs.MatchPluginsResult;
+
+/**
+ * Defines how a user can match plugins by an identifier.
+ * This is planned to be used to fetch details about PluginModels
+ * from the database when we have limited information
+ * (ex. PluginLock only stores Plugin "names" for some reason).
+ * This can also be used by CheckForUpdatesBoundary.
+ */
+public interface MatchPluginsBoundary {
+    /**
+     * Looks through the database for plugins that match the model id's in input.
+     *
+     * @param input A list of plugin identifiers that will be searched for in the database.
+     * @return A map of all identifiers to the underlying PluginModel objects (if found).
+     */
+    MatchPluginsResult match(MatchPluginsInput input);
+}

--- a/src/main/java/org/hydev/mcpm/client/database/inputs/CheckForUpdatesInput.java
+++ b/src/main/java/org/hydev/mcpm/client/database/inputs/CheckForUpdatesInput.java
@@ -1,0 +1,16 @@
+package org.hydev.mcpm.client.database.inputs;
+
+import org.hydev.mcpm.client.database.model.PluginVersionState;
+
+import java.util.List;
+
+/**
+ * Input for the CheckForUpdatesBoundary.
+ *
+ * @param states A list of all plugins that should be considered for updates.
+ * @param noCache If true, the ListPackagesBoundary will re-download the database before performing the request.
+ */
+public record CheckForUpdatesInput(
+    List<PluginVersionState> states,
+    boolean noCache
+) { }

--- a/src/main/java/org/hydev/mcpm/client/database/inputs/CheckForUpdatesResult.java
+++ b/src/main/java/org/hydev/mcpm/client/database/inputs/CheckForUpdatesResult.java
@@ -1,0 +1,41 @@
+package org.hydev.mcpm.client.database.inputs;
+
+import org.hydev.mcpm.client.database.model.PluginVersionState;
+import org.hydev.mcpm.client.models.PluginModel;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Result returned from CheckForUpdatesBoundary.
+ * If a plugin is in the mismatched list, you might want to ask the user if they can be removed.
+ *
+ * @param state The outcome of the request. Must be Success for the other values to be valid.
+ * @param updatable A map from version ids to all plugins that require updates.
+ * @param mismatched A list of all plugins that were not matched to any Plugin in the database.
+ */
+public record CheckForUpdatesResult(
+    State state,
+    Map<PluginVersionState, PluginModel> updatable,
+    List<PluginVersionState> mismatched
+) {
+    /**
+     * The outcome of the CheckForUpdatesResult.
+     */
+    public enum State {
+        SUCCESS,
+        INVALID_INPUT,
+        FAILED_TO_FETCH_DATABASE,
+    }
+
+    /**
+     * Creates an empty CheckForUpdatesResult with the provided state.
+     * The default values are provided in order to easily create objects with failure States.
+     *
+     * @param state The state of the CheckForUpdatesResult.
+     * @return A CheckForUpdatesResult object with state initialized and dummy values for the other elements.
+     */
+    public static CheckForUpdatesResult by(CheckForUpdatesResult.State state) {
+        return new CheckForUpdatesResult(state, Map.of(), List.of());
+    }
+}

--- a/src/main/java/org/hydev/mcpm/client/database/inputs/MatchPluginsInput.java
+++ b/src/main/java/org/hydev/mcpm/client/database/inputs/MatchPluginsInput.java
@@ -1,0 +1,16 @@
+package org.hydev.mcpm.client.database.inputs;
+
+import org.hydev.mcpm.client.database.model.PluginModelId;
+
+import java.util.List;
+
+/**
+ * Input for the MatchPluginsInput.
+ *
+ * @param pluginIds A list of all plugins that should be considered for updates.
+ * @param noCache If true, the ListPackagesBoundary will re-download the database before performing the request.
+ */
+public record MatchPluginsInput(
+    List<PluginModelId> pluginIds,
+    boolean noCache
+) { }

--- a/src/main/java/org/hydev/mcpm/client/database/inputs/MatchPluginsResult.java
+++ b/src/main/java/org/hydev/mcpm/client/database/inputs/MatchPluginsResult.java
@@ -1,0 +1,44 @@
+package org.hydev.mcpm.client.database.inputs;
+
+import org.bukkit.plugin.Plugin;
+import org.hydev.mcpm.client.database.model.PluginModelId;
+import org.hydev.mcpm.client.database.model.PluginVersionState;
+import org.hydev.mcpm.client.models.PluginModel;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Result returned from CheckForUpdatesBoundary.
+ * If a plugin is in the mismatched list, you might want to ask the user if they can be removed.
+ *
+ * @param state The outcome of the request. Must be Success for the other values to be valid.
+ * @param matched A map from version ids to all plugins that match the condition (e.g. needs updates).
+ * @param mismatched A list of all plugins that were not matched to any Plugin in the database.
+ */
+public record MatchPluginsResult(
+    State state,
+    Map<PluginModelId, PluginModel> matched,
+    List<PluginModelId> mismatched
+) {
+    /**
+     * The outcome of the MatchPluginsInput.
+     */
+    public enum State {
+        SUCCESS,
+        INVALID_INPUT,
+        FAILED_TO_FETCH_DATABASE,
+    }
+
+    /**
+     * Creates an empty MatchPluginsResult with the provided state.
+     * The default values are provided in order to easily create objects with failure States.
+     *
+     * @param state The state of the MatchPluginsResult.
+     * @return A MatchPluginsResult object with state initialized and dummy values for the other elements.
+     */
+    public static MatchPluginsResult by(MatchPluginsResult.State state) {
+        return new MatchPluginsResult(state, Map.of(), List.of());
+    }
+}

--- a/src/main/java/org/hydev/mcpm/client/database/model/PluginModelId.java
+++ b/src/main/java/org/hydev/mcpm/client/database/model/PluginModelId.java
@@ -1,0 +1,86 @@
+package org.hydev.mcpm.client.database.model;
+
+import org.hydev.mcpm.client.models.PluginModel;
+import org.hydev.mcpm.client.models.PluginVersion;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.text.html.Option;
+import java.util.OptionalLong;
+
+/**
+ * Used to identify a plugin based on many qualifications (id/name/main class).
+ * At least one of pluginId | pluginName | pluginMain must be provided.
+ * If more than one of these qualifications are provided, then plugins must match all provided entries.
+ *
+ * @param pluginId The plugin id. See PluginModel#id.
+ * @param pluginName The plugin name. See PluginYML#name.
+ * @param pluginMain The plugin main class. See PluginYML#main.
+ */
+public record PluginModelId(
+    // No sum types.
+    OptionalLong pluginId,
+    @Nullable String pluginName,
+    @Nullable String pluginMain
+) {
+    /**
+     * Checks if this object is in a valid state.
+     *
+     * @return True if at least one of pluginId or pluginName is pluginMain.
+     */
+    public boolean valid() {
+        return pluginId.isPresent() || pluginName != null || pluginMain != null;
+    }
+
+    /**
+     * Returns true if the provided PluginModel object matches this PluginModelId object.
+     *
+     * @param model The provided PluginModel object.
+     * @return True if the provided pluginId, pluginName or pluginString matches the PluginModel object.
+     */
+    public boolean matches(PluginModel model) {
+        if (pluginId.isPresent() && pluginId.getAsLong() != model.id()) {
+            return false;
+        }
+
+        var optionalMeta = model.latest().map(PluginVersion::meta);
+
+        if (optionalMeta.isEmpty()) {
+            return false;
+        }
+
+        var meta = optionalMeta.get();
+
+        return (pluginName == null || pluginName.equals(meta.name()))
+            && (pluginMain == null || pluginMain.equals(meta.main()));
+    }
+
+    /**
+     * Returns a PluginModelId where the only populated field is pluginId.
+     *
+     * @param id The value for the id field.
+     * @return A plugin id object.
+     */
+    public static PluginModelId byId(long id) {
+        return new PluginModelId(OptionalLong.of(id), null, null);
+    }
+
+    /**
+     * Returns a PluginModelId where the only populated field is pluginName.
+     *
+     * @param name The value for the name field.
+     * @return A plugin id object.
+     */
+    public static PluginModelId byName(String name) {
+        return new PluginModelId(OptionalLong.empty(), name, null);
+    }
+
+     /**
+     * Returns a PluginModelId where the only populated field is pluginMain.
+     *
+     * @param main The value for the main field.
+     * @return A plugin id object.
+     */
+    public static PluginModelId byMain(String main) {
+        return new PluginModelId(OptionalLong.empty(), null, main);
+    }
+}

--- a/src/main/java/org/hydev/mcpm/client/database/model/PluginVersionId.java
+++ b/src/main/java/org/hydev/mcpm/client/database/model/PluginVersionId.java
@@ -1,0 +1,59 @@
+package org.hydev.mcpm.client.database.model;
+
+import org.hydev.mcpm.client.models.PluginVersion;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.OptionalLong;
+
+/**
+ * Used to identify a plugin version based on many qualifications (id/user string).
+ * At least one of versionId | versionString must be provided.
+ * If more than one of these qualifications are provided, then plugins must match all provided entries.
+ *
+ * @param versionId The id for the installed PluginVersion. See PluginVersion#id.
+ * @param versionString The user string for the installed PluginVersion. See PluginYML#version.
+ */
+public record PluginVersionId(
+    OptionalLong versionId,
+    @Nullable String versionString
+) {
+    /**
+     * Checks if this object is in a valid state.
+     *
+     * @return True if at least one of versionId or versionString is specified.
+     */
+    public boolean valid() {
+        return versionId.isPresent() || versionString != null;
+    }
+
+    /**
+     * Returns true if the provided PluginVersion object matches this PluginVersionId object.
+     *
+     * @param version The provided PluginVersion object.
+     * @return True if the provided versionId or versionString matches the PluginVersion object.
+     */
+    public boolean matches(PluginVersion version) {
+        return (versionId.isEmpty() || versionId.getAsLong() == version.id())
+            && (versionString == null || versionString.equals(version.meta().version()));
+    }
+
+    /**
+     * Returns a PluginVersion where the only populated field is versionId.
+     *
+     * @param id The value for the id field.
+     * @return A plugin version id object.
+     */
+    public static PluginVersionId byId(long id) {
+        return new PluginVersionId(OptionalLong.of(id), null);
+    }
+
+    /**
+     * Returns a PluginVersion where the only populated field is versionString.
+     *
+     * @param string The value for the string field.
+     * @return A plugin version id object.
+     */
+    public static PluginVersionId byString(String string) {
+        return new PluginVersionId(OptionalLong.empty(), string);
+    }
+}

--- a/src/main/java/org/hydev/mcpm/client/database/model/PluginVersionState.java
+++ b/src/main/java/org/hydev/mcpm/client/database/model/PluginVersionState.java
@@ -1,0 +1,15 @@
+package org.hydev.mcpm.client.database.model;
+
+/**
+ * Used to present the current state of a plugin version for CheckForUpdatesBoundary.
+ *
+ * @param modelId An identifier for this plugin.
+ *                Example `PluginModelId.byName("OwnPlots")`.
+ * @param versionId An identifier for the version this plugin is currently at.
+ *                  Example `PluginVersionId.byString("1.2.1")`.
+ */
+public record PluginVersionState(
+    // No sum types.
+    PluginModelId modelId,
+    PluginVersionId versionId
+) { }

--- a/src/main/java/org/hydev/mcpm/client/models/PluginModel.java
+++ b/src/main/java/org/hydev/mcpm/client/models/PluginModel.java
@@ -1,6 +1,8 @@
 package org.hydev.mcpm.client.models;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -17,4 +19,12 @@ public record PluginModel(
     List<PluginVersion> versions
 )
 {
+    /**
+     * Returns the latest version.
+     *
+     * @return The PluginVersion with the greatest id (apparently newer states take higher values?).
+     */
+    public Optional<PluginVersion> latest() {
+        return versions().stream().max(Comparator.comparingLong(PluginVersion::id));
+    }
 }


### PR DESCRIPTION
I've added the work around the CheckForUpdates boundary.

I've made sure to try to allow it to handle multiple types of inputs (by id/name/string) since I'm not sure what the lock file will contain (or what will be feasible).

I've also added a MatchPlugins boundary to allow other parts of the program to look up plugins based on information from a lock file if needed (hopefully).