### PR TITLE
[O] Avoid build in gradle test workflow

### DIFF
--- a/.github/workflows/gradle-check.yml
+++ b/.github/workflows/gradle-check.yml
@@ -27,4 +27,6 @@ jobs:
         uses: gradle/gradle-build-action@v2.3.3
 
       - name: Gradle Checkstyle
-        run: ./gradlew check
+        run: |
+          ./gradlew checkStyleMain
+          ./gradlew checkStyleTest

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Setup Gradle with Dependency Cache
         uses: gradle/gradle-build-action@v2.3.3
 
-      - name: Gradle Build
-        run: ./gradlew build --scan
-
       - name: Gradle Test
         run: ./gradlew test
 


### PR DESCRIPTION
Previously the gradle build action runs checkstyle as well, making the checkstyle action useless.