### PR TITLE
Add update tests

### DIFF
--- a/src/main/java/org/hydev/mcpm/client/DatabaseManager.java
+++ b/src/main/java/org/hydev/mcpm/client/DatabaseManager.java
@@ -44,6 +44,10 @@ public class DatabaseManager {
      * @param pluginName The version of the installed plugin
      * */
     public boolean checkPluginInstalledByName(String pluginName) {
+        if (!localPluginTracker.findIfInLockByName(pluginName)) {
+            return false;
+        }
+
         List<PluginYml> pluginInstalled = localPluginTracker.listInstalled();
         for (PluginYml pluginYml : pluginInstalled) {
             if (pluginYml != null && pluginYml.name() != null && pluginYml.name().equals(pluginName)) {
@@ -65,7 +69,8 @@ public class DatabaseManager {
         for (PluginYml pluginYml : pluginInstalled) {
             if (pluginYml != null && pluginYml.version() != null &&
                     pluginYml.version().equals(version)) {
-                return true;
+                // Yes, if it is not in the plugin tracker lock file, we ignore.
+                return localPluginTracker.findIfInLockByName(pluginYml.name());
             }
         }
         return false;

--- a/src/main/java/org/hydev/mcpm/client/updater/UpdateInteractor.java
+++ b/src/main/java/org/hydev/mcpm/client/updater/UpdateInteractor.java
@@ -1,9 +1,9 @@
 package org.hydev.mcpm.client.updater;
 
 import org.hydev.mcpm.client.commands.presenters.InstallResultPresenter;
+import org.hydev.mcpm.client.database.tracker.PluginTracker;
 import org.hydev.mcpm.client.installer.InstallBoundary;
 import org.hydev.mcpm.client.installer.input.InstallInput;
-import org.hydev.mcpm.client.local.LocalPluginTracker;
 import org.hydev.mcpm.client.matcher.PluginModelId;
 import org.hydev.mcpm.client.matcher.PluginVersionId;
 import org.hydev.mcpm.client.matcher.PluginVersionState;
@@ -30,7 +30,7 @@ import static org.hydev.mcpm.client.updater.UpdateOutcome.State.*;
 public record UpdateInteractor(
         CheckForUpdatesBoundary checkBoundary,
         InstallBoundary installer,
-        LocalPluginTracker pluginTracker
+        PluginTracker pluginTracker
 ) implements UpdateBoundary {
     @Nullable
     private PluginVersionState stateByName(Map<String, PluginYml> installed, String name) {
@@ -52,7 +52,7 @@ public record UpdateInteractor(
             .collect(Pair.toMap());
 
         return names.stream()
-            .map(name -> new Pair<>(name, stateByName(installed, name)))
+            .map(name -> Pair.of(name, stateByName(installed, name)))
             .filter(pair -> pair.getValue() != null)
             .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
     }
@@ -101,7 +101,7 @@ public record UpdateInteractor(
                                       InstallResultPresenter installResultPresenter) {
         // E.g. was filtered in stateMapByNames since there was no associated version.
         if (state == null) {
-            defaultOutcomeFor(null, NOT_INSTALLED);
+            return defaultOutcomeFor(null, NOT_INSTALLED);
         }
 
         if (result.mismatched().contains(state)) {

--- a/src/test/java/org/hydev/mcpm/client/database/CheckForUpdatesInteractorTest.java
+++ b/src/test/java/org/hydev/mcpm/client/database/CheckForUpdatesInteractorTest.java
@@ -47,9 +47,9 @@ public class CheckForUpdatesInteractorTest {
 
         smallInteractor = interactor(List.of(
             PluginMockFactory.model(1),
-            PluginMockFactory.model(2, "name", null, List.of("ver.1", "ver.2"), null),
-            PluginMockFactory.model(3, "test", null, List.of("update", "update update"), null),
-            PluginMockFactory.model(4, "test", null, List.of("1.0", "2.0", "3.0"), null)
+            PluginMockFactory.model(2, "name", List.of("ver.1", "ver.2")),
+            PluginMockFactory.model(3, "test", List.of("update", "update update")),
+            PluginMockFactory.model(4, "test", List.of("1.0", "2.0", "3.0"))
         ));
     }
 

--- a/src/test/java/org/hydev/mcpm/client/database/MockInstaller.java
+++ b/src/test/java/org/hydev/mcpm/client/database/MockInstaller.java
@@ -1,0 +1,59 @@
+package org.hydev.mcpm.client.database;
+
+import org.hydev.mcpm.client.commands.presenters.InstallResultPresenter;
+import org.hydev.mcpm.client.database.tracker.PluginTracker;
+import org.hydev.mcpm.client.installer.InstallBoundary;
+import org.hydev.mcpm.client.installer.input.InstallInput;
+import org.hydev.mcpm.client.models.PluginModel;
+import org.hydev.mcpm.client.models.PluginVersion;
+import org.hydev.mcpm.client.search.SearchPackagesType;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class MockInstaller implements InstallBoundary {
+    private final List<PluginModel> plugins;
+    private final PluginTracker tracker;
+    private final boolean defaultResult;
+    private final Set<String> requested = new HashSet<>();
+
+    public MockInstaller(List<PluginModel> plugins, PluginTracker tracker) {
+        this(plugins, tracker, true);
+    }
+
+    public MockInstaller(List<PluginModel> plugins, PluginTracker tracker, boolean defaultResult) {
+        this.plugins = plugins;
+        this.tracker = tracker;
+        this.defaultResult = defaultResult;
+    }
+
+    @Override
+    public boolean installPlugin(InstallInput installInput, InstallResultPresenter resultPresenter) {
+        Assertions.assertEquals(installInput.type(), SearchPackagesType.BY_NAME);
+
+        if (tracker.findIfInLockByName(installInput.name()))
+            return false;
+
+        var model = plugins.stream()
+            .filter(plugin -> plugin.getLatestPluginVersion()
+                .map(x -> x.meta() != null && installInput.name().equals(x.meta().name()))
+                .orElse(false)
+            ).findFirst();
+
+        var modelId = model.map(PluginModel::id).orElse(0L);
+        var versionId = model.map(x -> x.getLatestPluginVersion()
+            .map(PluginVersion::id).orElse(0L)
+        ).orElse(0L);
+
+        requested.add(installInput.name());
+        tracker.addEntry(installInput.name(), true, versionId, modelId);
+
+        return defaultResult;
+    }
+
+    Set<String> getRequested() {
+        return new HashSet<>(requested);
+    }
+}

--- a/src/test/java/org/hydev/mcpm/client/database/MockInstaller.java
+++ b/src/test/java/org/hydev/mcpm/client/database/MockInstaller.java
@@ -13,16 +13,32 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Mock installer utility that keeps track of plugins that were requested to be installed.
+ */
 public class MockInstaller implements InstallBoundary {
     private final List<PluginModel> plugins;
     private final PluginTracker tracker;
     private final boolean defaultResult;
     private final Set<String> requested = new HashSet<>();
 
+    /**
+     * Creates a new MockInstaller object that always succeeds (when it is not already installed).
+     *
+     * @param plugins A list of plugins to lookup plugin related information about (to pass to PluginTracker).
+     * @param tracker A plugin tracker to query whether a plugin is installed.
+     */
     public MockInstaller(List<PluginModel> plugins, PluginTracker tracker) {
         this(plugins, tracker, true);
     }
 
+    /**
+     * Creates a new MockInstaller object.
+     *
+     * @param plugins A list of plugins to lookup plugin related information about (to pass to PluginTracker).
+     * @param tracker A plugin tracker to query whether a plugin is installed.
+     * @param defaultResult Determines what the installer should return when installPlugin is invoked.
+     */
     public MockInstaller(List<PluginModel> plugins, PluginTracker tracker, boolean defaultResult) {
         this.plugins = plugins;
         this.tracker = tracker;
@@ -53,6 +69,11 @@ public class MockInstaller implements InstallBoundary {
         return defaultResult;
     }
 
+    /**
+     * Returns a list of all plugin names that were passed to installPlugin (and succeeded).
+     *
+     * @return A list of plugin names.
+     */
     Set<String> getRequested() {
         return new HashSet<>(requested);
     }

--- a/src/test/java/org/hydev/mcpm/client/database/MockPluginTracker.java
+++ b/src/test/java/org/hydev/mcpm/client/database/MockPluginTracker.java
@@ -8,6 +8,12 @@ import org.hydev.mcpm.utils.Pair;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Mock implementation of the PluginTracker interface.
+ *
+ * @param entries A list of all entries in the lockfile.
+ * @param installed A list of all "Installed" PluginYml files (to be returned in listInstalled).
+ */
 public record MockPluginTracker(
     Map<String, Boolean> entries,
     List<PluginYml> installed

--- a/src/test/java/org/hydev/mcpm/client/database/MockPluginTracker.java
+++ b/src/test/java/org/hydev/mcpm/client/database/MockPluginTracker.java
@@ -1,0 +1,86 @@
+package org.hydev.mcpm.client.database;
+
+import org.hydev.mcpm.client.database.tracker.PluginTracker;
+import org.hydev.mcpm.client.models.PluginTrackerModel;
+import org.hydev.mcpm.client.models.PluginYml;
+import org.hydev.mcpm.utils.Pair;
+
+import java.util.List;
+import java.util.Map;
+
+public record MockPluginTracker(
+    Map<String, Boolean> entries,
+    List<PluginYml> installed
+) implements PluginTracker {
+    private static Map<String, Boolean> makeEntries(List<PluginYml> installed) {
+        return installed.stream()
+            .map(x -> Pair.of(x.name(), true))
+            .collect(Pair.<String, Boolean>toMap());
+    }
+
+    public MockPluginTracker(List<PluginYml> installed) {
+        this(makeEntries(installed), installed);
+    }
+
+
+    @Override
+    public void addEntry(String name, boolean status, long versionId, long pluginId) {
+        entries.put(name, status);
+    }
+
+    @Override
+    public void removeEntry(String name) {
+        entries.remove(name);
+    }
+
+    @Override
+    public List<PluginTrackerModel> listEntries() {
+        return null;
+    }
+
+    @Override
+    public List<PluginYml> listInstalled() {
+        return installed;
+    }
+
+    @Override
+    public void setManuallyInstalled(String name) {
+        if (!entries.containsKey(name)) {
+            return;
+        }
+
+        entries.put(name, true);
+    }
+
+    @Override
+    public void removeManuallyInstalled(String name) {
+        if (!entries.containsKey(name)) {
+            return;
+        }
+
+        entries.put(name, false);
+    }
+
+    @Override
+    public Boolean findIfInLockById(String id) {
+        return null;
+    }
+
+    @Override
+    public List<String> listManuallyInstalled() {
+        return entries().entrySet().stream()
+            .filter(Map.Entry::getValue)
+            .map(Map.Entry::getKey)
+            .toList();
+    }
+
+    @Override
+    public List<PluginYml> listOrphanPlugins(boolean considerSoftDependencies) {
+        return List.of();
+    }
+
+    @Override
+    public Boolean findIfInLockByName(String name) {
+        return entries.containsKey(name);
+    }
+}

--- a/src/test/java/org/hydev/mcpm/client/database/PluginMockFactory.java
+++ b/src/test/java/org/hydev/mcpm/client/database/PluginMockFactory.java
@@ -175,15 +175,18 @@ public class PluginMockFactory {
      * @return List of plugins for testing.
      */
     public static @Unmodifiable List<PluginModel> generateTestPlugins() {
-        String[] descriptions = {"WorldGuard lets you and players guard areas " +
-                "of land against griefers and undesirables as well " +
-                "as tweak and disable various gameplay features of Minecraft.",
-                "Multiverse was created at the dawn of Bukkit multiworld support. " +
-                        "It has since then grown into a complete world management " +
-                        "solution including special treatment of your nether worlds with " +
-                        "Multiverse NetherPortals.",
-                "Create futuristic holograms to display text and items to players!"
-        };
+        var worldGuardDescription = "WorldGuard lets you and players guard areas " +
+            "of land against griefers and undesirables as well " +
+            "as tweak and disable various gameplay features of Minecraft.";
+
+        var multiverseDescription = "Multiverse was created at the dawn of Bukkit multiworld support. " +
+            "It has since then grown into a complete world management " +
+            "solution including special treatment of your nether worlds with " +
+            "Multiverse NetherPortals.";
+
+        var hologramDescription = "Create futuristic holograms to display text and items to players!";
+
+        String[] descriptions = { worldGuardDescription, multiverseDescription, hologramDescription };
 
         return List.of(
                 PluginMockFactory.model(1),
@@ -193,7 +196,7 @@ public class PluginMockFactory {
                         createCommand(descriptions[0], List.of("/god", "/ungod"))),
                 PluginMockFactory.model(3, "Multiverse-Core", descriptions[1],
                         List.of("1.19.2", "1.19.1"),
-                        createCommand(descriptions[1],List.of("/mvlist", "/mvl"))),
+                        createCommand(descriptions[1], List.of("/mvlist", "/mvl"))),
                 PluginMockFactory.model(4, "Holographic Displays", descriptions[2],
                         List.of("1.19.2", "1.19.1", "1.19"),
                         createCommand(descriptions[2], List.of("/hd", "/ungod")))

--- a/src/test/java/org/hydev/mcpm/client/database/PluginMockFactory.java
+++ b/src/test/java/org/hydev/mcpm/client/database/PluginMockFactory.java
@@ -68,6 +68,18 @@ public class PluginMockFactory {
     }
 
     /**
+     * Creates a mock PluginYml object.
+     *
+     * @param name The name of the plugin.
+     * @param version The version string for the plugin.
+     * @param description The description for the plugin.
+     * @return A PluginYml object.
+     */
+    public static PluginYml meta(String name, String version, String description) {
+        return meta(name, version, description, null);
+    }
+
+    /**
      * Creates a mock PluginVersion object.
      *
      * @param id The version id.
@@ -76,7 +88,7 @@ public class PluginMockFactory {
      * @return A PluginVersion object.
      */
     public static PluginVersion version(long id, String name, String string) {
-        return new PluginVersion(id, 0, "", meta(name, string, null, null));
+        return version(id, name, string, name, null);
     }
 
     /**
@@ -89,8 +101,10 @@ public class PluginMockFactory {
      * @param commands The commands in the plugin.
      * @return A PluginVersion object.
      */
-    public static PluginVersion version(long id, String name, String string, String description,
-                                        Map<String, PluginCommand> commands) {
+    public static PluginVersion version(
+        long id, String name, String string, String description,
+        Map<String, PluginCommand> commands
+    ) {
         return new PluginVersion(id, 0, "", meta(name, string, description, commands));
     }
 
@@ -118,6 +132,20 @@ public class PluginMockFactory {
                 id,
                 List.of(version(id, name, "ver." + name)) // NOT SEMVER
         );
+    }
+
+    /**
+     * Creates a mock PluginModel object.
+     * The first version in versionNames will have id 0, the next will have id 1, and so on...
+     * Commands are defaulted to null.
+     *
+     * @param id The plugin id.
+     * @param name The plugin name.
+     * @param versionNames The individual version strings for each version.
+     * @return A PluginModel object.
+     */
+    public static PluginModel model(long id, String name, List<String> versionNames) {
+        return model(id, name, name, versionNames, null);
     }
 
     /**

--- a/src/test/java/org/hydev/mcpm/client/database/SilentInstallPresenter.java
+++ b/src/test/java/org/hydev/mcpm/client/database/SilentInstallPresenter.java
@@ -1,0 +1,11 @@
+package org.hydev.mcpm.client.database;
+
+import org.hydev.mcpm.client.commands.presenters.InstallResultPresenter;
+import org.hydev.mcpm.client.installer.InstallResult;
+
+public class SilentInstallPresenter implements InstallResultPresenter {
+    @Override
+    public void displayResult(InstallResult installResult, String name) {
+        /* do nothing */
+    }
+}

--- a/src/test/java/org/hydev/mcpm/client/database/SilentInstallPresenter.java
+++ b/src/test/java/org/hydev/mcpm/client/database/SilentInstallPresenter.java
@@ -3,6 +3,9 @@ package org.hydev.mcpm.client.database;
 import org.hydev.mcpm.client.commands.presenters.InstallResultPresenter;
 import org.hydev.mcpm.client.installer.InstallResult;
 
+/**
+ * Mock Install Presenter that does nothing on invocation.
+ */
 public class SilentInstallPresenter implements InstallResultPresenter {
     @Override
     public void displayResult(InstallResult installResult, String name) {

--- a/src/test/java/org/hydev/mcpm/client/database/UpdateInteractorTest.java
+++ b/src/test/java/org/hydev/mcpm/client/database/UpdateInteractorTest.java
@@ -1,0 +1,255 @@
+package org.hydev.mcpm.client.database;
+
+import org.hydev.mcpm.client.commands.presenters.InstallResultPresenter;
+import org.hydev.mcpm.client.database.fetcher.ConstantFetcher;
+import org.hydev.mcpm.client.database.fetcher.QuietFetcherListener;
+import org.hydev.mcpm.client.matcher.MatchPluginsInteractor;
+import org.hydev.mcpm.client.models.PluginModel;
+import org.hydev.mcpm.client.updater.CheckForUpdatesInteractor;
+import org.hydev.mcpm.client.updater.UpdateBoundary;
+import org.hydev.mcpm.client.updater.UpdateInput;
+import org.hydev.mcpm.client.updater.UpdateInteractor;
+import org.hydev.mcpm.client.updater.UpdateOutcome;
+import org.hydev.mcpm.client.updater.UpdateResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UpdateInteractorTest {
+    private static final InstallResultPresenter installPresenter = new SilentInstallPresenter();
+
+    private record MockPackage(
+        UpdateBoundary updator,
+        MockPluginTracker pluginTracker,
+        MockInstaller mockInstaller
+    ) { }
+
+    private static MockPackage interactor(
+        List<PluginModel> plugins,
+        Map<Long, String> installedVersions,
+        boolean installerSucceeds,
+        boolean emptyDatabase
+    ) {
+        var fetcher = new ConstantFetcher(emptyDatabase ? List.of() : plugins);
+        var listener = new QuietFetcherListener();
+
+        // Best to mock this too, but these tests were tied to this originally.
+        var matcher = new MatchPluginsInteractor(fetcher, listener);
+        var checker = new CheckForUpdatesInteractor(matcher);
+
+        var installed = plugins.stream()
+            .filter(plugin -> installedVersions.containsKey(plugin.id()))
+            .map(plugin -> plugin.versions().stream()
+                .filter(version -> installedVersions.get(plugin.id()).equals(version.meta().version()))
+                .findFirst())
+            .filter(Optional::isPresent)
+            .map(version -> version.get().meta())
+            .toList();
+
+        var tracker = new MockPluginTracker(installed);
+        var installer = new MockInstaller(plugins, tracker, installerSucceeds);
+
+        var interactor = new UpdateInteractor(checker, installer, tracker);
+
+        return new MockPackage(
+            interactor,
+            tracker,
+            installer
+        );
+    }
+
+    private static List<PluginModel> defaultPlugins() {
+        return List.of(
+            PluginMockFactory.model(1, "TpProtect", List.of("0.0.0.0.1", "0.0.3", "9.99")),
+            PluginMockFactory.model(2, "JedCore", List.of("version-1", "version-2", "version-3")),
+            PluginMockFactory.model(3, "Apples+", List.of("1.0", "1.2")),
+            PluginMockFactory.model(4, "TpProtect", List.of("0.0.0.0.1", "0.0.3", "9.99"))
+        );
+    }
+
+    private static MockPackage emptyInteractor() {
+        return interactor(List.of(), Map.of(), true, false);
+    }
+
+    private static MockPackage emptyWithInstalledInteractor() {
+        return interactor(
+            defaultPlugins(),
+            Map.of(2L, "version-2"),
+            true, true
+        );
+    }
+
+    private static MockPackage upToDateInteractor() {
+        return interactor(defaultPlugins(), Map.of(
+            2L, "version-3",
+            3L, "1.2",
+            4L, "9.99"
+        ), true, false);
+    }
+
+    private static MockPackage oneOldInteractor() {
+        return interactor(defaultPlugins(), Map.of(
+            2L, "version-2",
+            3L, "1.2",
+            4L, "9.99"
+        ), true, false);
+    }
+
+    private static MockPackage failingOneOldInteractor() {
+        return interactor(defaultPlugins(), Map.of(
+            2L, "version-2",
+            3L, "1.2",
+            4L, "9.99"
+        ), false, false);
+    }
+
+    private static MockPackage outOfDateInteractor() {
+        return interactor(defaultPlugins(), Map.of(
+            2L, "version-2",
+            3L, "1.0",
+            4L, "0.0.3"
+        ), true, false);
+    }
+
+    private static void assertUpToDate(UpdateOutcome outcome, String version) {
+        assertEquals(outcome.state(), UpdateOutcome.State.UP_TO_DATE);
+        assertEquals(outcome.initialVersion(), version);
+        assertNull(outcome.destinationVersion());
+    }
+
+    private static void assertUpdated(UpdateOutcome outcome, String version, String destination) {
+        assertEquals(outcome.state(), UpdateOutcome.State.UPDATED);
+        assertEquals(outcome.initialVersion(), version);
+        assertEquals(outcome.destinationVersion(), destination);
+    }
+
+    @Test
+    void testEmptyDatabase() {
+        var mock = emptyInteractor();
+
+        var input = new UpdateInput(List.of(), false, false, installPresenter);
+        var result = mock.updator.update(input);
+
+        assertEquals(result.state(), UpdateResult.State.SUCCESS);
+        assertTrue(mock.mockInstaller().getRequested().isEmpty());
+        assertTrue(result.outcomes().isEmpty());
+    }
+
+    @Test
+    void testMismatchedPlugin() {
+        var mock = emptyWithInstalledInteractor();
+
+        var input = new UpdateInput(List.of("JedCore"), false, false, installPresenter);
+        var result = mock.updator.update(input);
+
+        assertEquals(result.state(), UpdateResult.State.SUCCESS);
+        assertTrue(mock.mockInstaller().getRequested().isEmpty());
+        assertEquals(result.outcomes().get("JedCore").state(), UpdateOutcome.State.MISMATCHED);
+    }
+
+    @Test
+    void testMismatchedName() {
+        var mock = emptyInteractor();
+
+        var input = new UpdateInput(List.of("JedCore"), false, false, installPresenter);
+        var result = mock.updator.update(input);
+
+        assertEquals(result.state(), UpdateResult.State.SUCCESS);
+        assertTrue(mock.mockInstaller().getRequested().isEmpty());
+        assertEquals(result.outcomes().get("JedCore").state(), UpdateOutcome.State.NOT_INSTALLED);
+    }
+
+    @Test
+    void testAllUpToDate() {
+        var mock = upToDateInteractor();
+
+        var input = new UpdateInput(List.of(), false, false, installPresenter);
+        var result = mock.updator.update(input);
+
+        assertEquals(result.state(), UpdateResult.State.SUCCESS);
+        assertTrue(mock.mockInstaller().getRequested().isEmpty());
+        assertEquals(result.outcomes().size(), 3);
+        assertUpToDate(result.outcomes().get("JedCore"), "version-3");
+        assertUpToDate(result.outcomes().get("Apples+"), "1.2");
+        assertUpToDate(result.outcomes().get("TpProtect"), "9.99");
+    }
+
+    @Test
+    void testOneUpToDate() {
+        var mock = upToDateInteractor();
+
+        var input = new UpdateInput(List.of("Apples+"), false, false, installPresenter);
+        var result = mock.updator.update(input);
+
+        assertEquals(result.state(), UpdateResult.State.SUCCESS);
+        assertTrue(mock.mockInstaller().getRequested().isEmpty());
+        assertEquals(result.outcomes().size(), 1);
+        assertUpToDate(result.outcomes().get("Apples+"), "1.2");
+    }
+
+    @Test
+    void testAllOutOfDate() {
+        var mock = outOfDateInteractor();
+
+        var input = new UpdateInput(List.of(), false, false, installPresenter);
+        var result = mock.updator.update(input);
+
+        assertEquals(result.state(), UpdateResult.State.SUCCESS);
+        assertEquals(mock.mockInstaller().getRequested(), Set.of("JedCore", "Apples+", "TpProtect"));
+        assertEquals(result.outcomes().size(), 3);
+        assertUpdated(result.outcomes().get("JedCore"), "version-2", "version-3");
+        assertUpdated(result.outcomes().get("Apples+"), "1.0", "1.2");
+        assertUpdated(result.outcomes().get("TpProtect"), "0.0.3", "9.99");
+    }
+
+    @Test
+    void testOneOutOfDate() {
+        var mock = outOfDateInteractor();
+
+        var input = new UpdateInput(List.of("Apples+"), false, false, installPresenter);
+        var result = mock.updator.update(input);
+
+        assertEquals(result.state(), UpdateResult.State.SUCCESS);
+        assertEquals(mock.mockInstaller().getRequested(), Set.of("Apples+"));
+        assertEquals(result.outcomes().size(), 1);
+        assertUpdated(result.outcomes().get("Apples+"), "1.0", "1.2");
+    }
+
+    @Test
+    void testAllMixed() {
+        var mock = oneOldInteractor();
+
+        var input = new UpdateInput(List.of(), false, false, installPresenter);
+        var result = mock.updator.update(input);
+
+        assertEquals(result.state(), UpdateResult.State.SUCCESS);
+        assertEquals(mock.mockInstaller().getRequested(), Set.of("JedCore"));
+        assertEquals(result.outcomes().size(), 3);
+        assertUpdated(result.outcomes().get("JedCore"), "version-2", "version-3");
+        assertUpToDate(result.outcomes().get("Apples+"), "1.2");
+        assertUpToDate(result.outcomes().get("TpProtect"), "9.99");
+    }
+
+    @Test
+    void testFailingInstaller() {
+        var mock = failingOneOldInteractor();
+
+        var input = new UpdateInput(List.of(), false, false, installPresenter);
+        var result = mock.updator.update(input);
+
+        assertEquals(result.state(), UpdateResult.State.SUCCESS);
+        assertEquals(result.outcomes().size(), 3);
+        assertEquals(result.outcomes().get("JedCore").state(), UpdateOutcome.State.NETWORK_ERROR);
+        assertFalse(result.outcomes().get("JedCore").state().success());
+        assertUpToDate(result.outcomes().get("Apples+"), "1.2");
+        assertUpToDate(result.outcomes().get("TpProtect"), "9.99");
+    }
+}

--- a/src/test/java/org/hydev/mcpm/utils/GeneralUtilsTest.java
+++ b/src/test/java/org/hydev/mcpm/utils/GeneralUtilsTest.java
@@ -1,5 +1,6 @@
 package org.hydev.mcpm.utils;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,6 +20,7 @@ class GeneralUtilsTest
     }
 
     @Test
+    @Tag("IntegrationTest")
     void safeSleep()
     {
         long time = System.currentTimeMillis();


### PR DESCRIPTION
This PR is a test patch for the update use case.
 - This test brings the coverage of the update package from 33% to 96%.
 - It also adds some utility mock classes for testing use cases that involve LocalPluginTracker.
 - It _does not_ remove LocalPluginTracker, that will be done in another PR.
 - It does fix some update related bugs that were still present.

Some new classes:
 - `MockInstaller`: Mocks the InstallBoundary interface, saves the successful "installations" into a list that can be checked.
 - `MockPluginTracker`: Holds PluginTracker data in a list that can be checked and edited. It does not persist, and can be modified and checked after a test completes.
 - `UpdateInteractorTest`: Contains some tests for the update use case! Yay.