### PR TITLE
Search Without Static Storage

### DIFF
--- a/src/main/java/org/hydev/mcpm/client/search/SearchInteractor.java
+++ b/src/main/java/org/hydev/mcpm/client/search/SearchInteractor.java
@@ -44,6 +44,7 @@ public class SearchInteractor implements SearchPackagesBoundary {
     @Override
     public SearchPackagesResult search(SearchPackagesInput input) {
         var database = fetcher.fetchDatabase(!input.noCache(), listener);
+        var factory = new SearcherFactory();
 
         if (database == null) {
             return SearchPackagesResult.by(SearchPackagesResult.State.FAILED_TO_FETCH_DATABASE);
@@ -56,6 +57,6 @@ public class SearchInteractor implements SearchPackagesBoundary {
         var plugins = database.plugins();
 
         return new SearchPackagesResult(SearchPackagesResult.State.SUCCESS,
-                SearcherFactory.createSearcher(input).getSearchList(searchStr, plugins));
+                factory.createSearcher(input).getSearchList(searchStr, plugins));
     }
 }

--- a/src/main/java/org/hydev/mcpm/client/search/SearchInteractor.java
+++ b/src/main/java/org/hydev/mcpm/client/search/SearchInteractor.java
@@ -12,6 +12,7 @@ import org.hydev.mcpm.client.display.progress.ProgressBarFetcherListener;
 public class SearchInteractor implements SearchPackagesBoundary {
     private final DatabaseFetcher fetcher;
     private final DatabaseFetcherListener listener;
+    private final SearcherFactory factory = new SearcherFactory();
 
     /**
      * Creates a new database with the provided database fetcher.
@@ -44,7 +45,6 @@ public class SearchInteractor implements SearchPackagesBoundary {
     @Override
     public SearchPackagesResult search(SearchPackagesInput input) {
         var database = fetcher.fetchDatabase(!input.noCache(), listener);
-        var factory = new SearcherFactory();
 
         if (database == null) {
             return SearchPackagesResult.by(SearchPackagesResult.State.FAILED_TO_FETCH_DATABASE);

--- a/src/main/java/org/hydev/mcpm/client/search/SearcherByCommand.java
+++ b/src/main/java/org/hydev/mcpm/client/search/SearcherByCommand.java
@@ -13,7 +13,7 @@ import java.util.Map;
  */
 public class SearcherByCommand implements Searcher {
 
-    private static Map<String, List<PluginModel>> commandMap = null;
+    private Map<String, List<PluginModel>> commandMap = null;
 
     /**
      * Returns a dictionary mapping the different commands to the matching plugins.
@@ -52,9 +52,9 @@ public class SearcherByCommand implements Searcher {
     @Override
     public List<PluginModel> getSearchList(String inp, List<PluginModel> plugins) {
         // Instantiate if null
-        if (SearcherByCommand.commandMap == null) {
-            SearcherByCommand.commandMap = constructSearchMaps(plugins);
+        if (commandMap == null) {
+            commandMap = constructSearchMaps(plugins);
         }
-        return SearcherByCommand.commandMap.getOrDefault(inp, List.of());
+        return commandMap.getOrDefault(inp, List.of());
     }
 }

--- a/src/main/java/org/hydev/mcpm/client/search/SearcherByKeyword.java
+++ b/src/main/java/org/hydev/mcpm/client/search/SearcherByKeyword.java
@@ -15,7 +15,7 @@ import java.util.Set;
  */
 public class SearcherByKeyword implements Searcher {
 
-    private static Map<String, List<PluginModel>> keywordMap = null;
+    private Map<String, List<PluginModel>> keywordMap = null;
 
     /**
      * Returns a dictionary mapping the different keywords to the matching plugins
@@ -59,13 +59,13 @@ public class SearcherByKeyword implements Searcher {
     public List<PluginModel> getSearchList(String inp, List<PluginModel> plugins) {
 
         // Instantiate if null
-        if (SearcherByKeyword.keywordMap == null) {
-            SearcherByKeyword.keywordMap = constructSearchMaps(plugins);
+        if (keywordMap == null) {
+            keywordMap = constructSearchMaps(plugins);
         }
         String [] keywords = inp.split(" "); // Should be a string
-        Set<PluginModel> res = new HashSet<>(SearcherByKeyword.keywordMap.getOrDefault(keywords[0], List.of()));
+        Set<PluginModel> res = new HashSet<>(keywordMap.getOrDefault(keywords[0], List.of()));
         for (int i = 1; i < keywords.length; i++) {
-            List<PluginModel> pl = SearcherByKeyword.keywordMap.getOrDefault(keywords[i], List.of());
+            List<PluginModel> pl = keywordMap.getOrDefault(keywords[i], List.of());
             res.retainAll(pl);
             if (res.isEmpty())
                 return List.of();

--- a/src/main/java/org/hydev/mcpm/client/search/SearcherByName.java
+++ b/src/main/java/org/hydev/mcpm/client/search/SearcherByName.java
@@ -13,7 +13,7 @@ import java.util.Map;
  */
 public class SearcherByName implements Searcher {
 
-    private static Map<String, List<PluginModel>> nameMap = null;
+    private Map<String, List<PluginModel>> nameMap = null;
 
     /**
      * Returns a dictionary mapping the different names to the matching plugins.
@@ -50,9 +50,9 @@ public class SearcherByName implements Searcher {
     @Override
     public List<PluginModel> getSearchList(String inp, List<PluginModel> plugins) {
         // Instantiate if null
-        if (SearcherByName.nameMap == null) {
-            SearcherByName.nameMap = constructSearchMaps(plugins);
+        if (nameMap == null) {
+            nameMap = constructSearchMaps(plugins);
         }
-        return SearcherByName.nameMap.getOrDefault(inp, List.of());
+        return nameMap.getOrDefault(inp, List.of());
     }
 }

--- a/src/main/java/org/hydev/mcpm/client/search/SearcherFactory.java
+++ b/src/main/java/org/hydev/mcpm/client/search/SearcherFactory.java
@@ -5,23 +5,33 @@ package org.hydev.mcpm.client.search;
  *
  */
 public class SearcherFactory {
+    SearcherByName nameSearcher;
+    SearcherByKeyword keywordSearcher;
+    SearcherByCommand commandSearcher;
 
     /**
      * Returns the new searcher object based on the input type.
      *
      * @param input Contains the search type in particular. See SearchPackagesInput for details.
      */
-    public static Searcher createSearcher(SearchPackagesInput input) {
-        return switch (input.type()) {
-            case BY_NAME ->
-                    new SearcherByName();
-
-            case BY_COMMAND ->
-                    new SearcherByCommand();
-
-            case BY_KEYWORD ->
-                    new SearcherByKeyword();
-
-        };
+    public Searcher createSearcher(SearchPackagesInput input) {
+        switch (input.type()) {
+            case BY_NAME -> {
+                if (nameSearcher == null)
+                    nameSearcher = new SearcherByName();
+                return nameSearcher;
+            }
+            case BY_COMMAND -> {
+                if (commandSearcher == null)
+                    commandSearcher = new SearcherByCommand();
+                return commandSearcher;
+            }
+            case BY_KEYWORD -> {
+                if (keywordSearcher == null)
+                    keywordSearcher = new SearcherByKeyword();
+                return keywordSearcher;
+            }
+        }
+        return nameSearcher;
     }
 }

--- a/src/test/java/org/hydev/mcpm/client/database/SearchInteractorTest.java
+++ b/src/test/java/org/hydev/mcpm/client/database/SearchInteractorTest.java
@@ -16,8 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test suite for the SearchInteractor class.
- *
- * @author Jerry Zhu (<a href="https://github.com/jerryzhu509">...</a>)
  */
 public class SearchInteractorTest {
     private static SearchInteractor database;
@@ -50,6 +48,10 @@ public class SearchInteractorTest {
                 .collect(Collectors.joining(delim));
     }
 
+    /**
+     * Tests search by name when there is a match. Using lower-case to ensure that the search is not
+     * case-sensitive.
+     */
     @Test
     void testSearchByNameSuccessMatch() {
         var result = database.search(
@@ -58,9 +60,12 @@ public class SearchInteractorTest {
         assertEquals(result.state(), SearchPackagesResult.State.SUCCESS);
 
         var text = formatStr(result, ", ");
-        assertEquals(text, "Multiverse-Core");
+        assertEquals("Multiverse-Core", text);
     }
 
+    /**
+     * Tests search by name when there is no match. Expect an empty string.
+     */
     @Test
     void testSearchByNameSuccessNoMatch() {
         var result = database.search(
@@ -69,9 +74,12 @@ public class SearchInteractorTest {
         assertEquals(result.state(), SearchPackagesResult.State.SUCCESS);
 
         var text = formatStr(result, ", ");
-        assertEquals(text, "");
+        assertEquals("", text);
     }
 
+    /**
+     * Tests search by keyword when there is a match.
+     */
     @Test
     void testSearchByKeywordSuccessMatch() {
         var result = database.search(
@@ -80,9 +88,12 @@ public class SearchInteractorTest {
         assertEquals(result.state(), SearchPackagesResult.State.SUCCESS);
 
         var text = formatStr(result, ", ");
-        assertEquals(text, "Holographic Displays, WorldGuard");
+        assertEquals("Holographic Displays, WorldGuard", text);
     }
 
+    /**
+     * Tests search by keyword when there is no match. Expect an empty string.
+     */
     @Test
     void testSearchByKeywordSuccessNoMatch() {
         var result = database.search(
@@ -91,9 +102,13 @@ public class SearchInteractorTest {
         assertEquals(result.state(), SearchPackagesResult.State.SUCCESS);
 
         var text = formatStr(result, ", ");
-        assertEquals(text, "");
+        assertEquals("", text);
     }
 
+
+    /**
+     * Tests search by command when there is a match.
+     */
     @Test
     @SuppressWarnings("SpellCheckingInspection")
     void testSearchByCommandSuccessMatch() {
@@ -103,9 +118,13 @@ public class SearchInteractorTest {
         assertEquals(result.state(), SearchPackagesResult.State.SUCCESS);
 
         var text = formatStr(result, ", ");
-        assertEquals(text, "WorldGuard, Holographic Displays");
+        assertEquals("WorldGuard, Holographic Displays", text);
     }
 
+
+    /**
+     * Tests search by command when there is no match.
+     */
     @Test
     void testSearchByCommandSuccessNoMatch() {
         var result = database.search(
@@ -114,9 +133,12 @@ public class SearchInteractorTest {
         assertEquals(result.state(), SearchPackagesResult.State.SUCCESS);
 
         var text = formatStr(result, ", ");
-        assertEquals(text, "");
+        assertEquals("", text);
     }
 
+    /**
+     * Tests invalid searches due to empty inputs.
+     */
     @Test
     void testInvalidSearch() {
         var result1 = database.search(


### PR DESCRIPTION
Per TA comments, I added comments to SearchInteractorTest that better illustrate what each function tests.
Before, I implicitly assumed that we will be working with just the same database, hence making the search maps static. However, this assumption is quite limiting, and ran into problems when tests are ran. Now, I basically just made them non-static and instead, reinstantiate the searchers when needed.

I also mixed up the order of assertEquals for expected and actual. Fixed now.